### PR TITLE
feature(device-integrity): Make it optional

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -149,10 +149,10 @@ enum DeviceBehaviorReputation {
 }
 
 type DeviceIntegrity = {
-  emulator: boolean
-  from_official_store: boolean
-  gps_spoofing: boolean
-  probable_root: boolean
+  emulator?: boolean
+  from_official_store?: boolean
+  gps_spoofing?: boolean
+  probable_root?: boolean
 }
 
 type LocationServices = {
@@ -184,7 +184,7 @@ type SignupEvidenceSummary = {
   addressMatch: AddressMatch
   deviceFraudReputation: DeviceFraudReputation
   deviceBehaviorReputation: DeviceBehaviorReputation
-  deviceIntegrity: DeviceIntegrity
+  deviceIntegrity?: DeviceIntegrity
   deviceModel: string
   geocodeQuality: GeocodeQuality
   locationEventsNearAddress: number
@@ -196,7 +196,7 @@ type TransactionEvidenceSummary = {
   accountIntegrity: AccountIntegrity
   addresses: Array<AddressEvidence>
   deviceBehaviorReputation: DeviceBehaviorReputation
-  deviceIntegrity: DeviceIntegrity
+  deviceIntegrity?: DeviceIntegrity
   deviceModel: string
   distanceToTrustedLocation: number
   knownAccount: boolean


### PR DESCRIPTION
Agora o DeviceIntegrity é opcional.

Mais Info:
https://www.notion.so/inlocoglobal/Handle-empty-device-integrity-fields-on-Node-lib-deprecate-regions-49f1d088a0ed41669d2894acf048eadc