### PR TITLE
feat/accounts api

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The official Node.js library for integrating with the Incognia API.
 
-Documentation can be found at <https://us.incognia.com>
+Documentation can be found at <https://developer.incognia.com/docs>
 
 ## Installation
 
@@ -147,6 +147,20 @@ try {
 }
 ```
 
+### Searching for accounts
+
+This method fetches every account associated with a specific installation, returning the number of accounts and an array containing the account IDs and related timestamps. Use this API to map the relationship between user accounts and devices.
+
+```js
+try {
+  const accounts = await incogniaApi.searchAccounts({
+    installationId: 'installation_id'
+  })
+} catch (error) {
+  console.log(error.message)
+}
+```
+
 ## Typescript enabled
 
 Thanks to Typescript, all methods attributes and data response are typed, meaning any typescript-enabled editor can take advantage of intellisense and auto-complete:
@@ -193,4 +207,4 @@ try {
 
 ## More documentation
 
-More documentation and code examples can be found at <https://us.incognia.com>
+More documentation and code examples can be found at <https://developer.incognia.com/docs>

--- a/src/incogniaApi.ts
+++ b/src/incogniaApi.ts
@@ -21,7 +21,9 @@ import {
   SignupResponse,
   Method,
   RegisterSignupProps,
-  RegisterTransactionProps
+  RegisterTransactionProps,
+  SearchAccountsBodyProps,
+  SearchAccountsResponse
 } from './types'
 
 type IncogniaApiConstructor = {
@@ -41,6 +43,7 @@ type ApiEndpoints = {
   SIGNUPS: string
   TRANSACTIONS: string
   FEEDBACKS: string
+  ACCOUNTS: string
 }
 
 const BASE_ENDPOINT = 'https://api.incognia.com/api'
@@ -49,7 +52,8 @@ export const apiEndpoints: ApiEndpoints = {
   TOKEN: `${BASE_ENDPOINT}/v2/token`,
   SIGNUPS: `${BASE_ENDPOINT}/v2/onboarding/signups`,
   TRANSACTIONS: `${BASE_ENDPOINT}/v2/authentication/transactions`,
-  FEEDBACKS: `${BASE_ENDPOINT}/v2/feedbacks`
+  FEEDBACKS: `${BASE_ENDPOINT}/v2/feedbacks`,
+  ACCOUNTS: `${BASE_ENDPOINT}/v2/accounts/search`
 }
 
 export class IncogniaApi {
@@ -137,6 +141,23 @@ export class IncogniaApi {
     const data = convertObjectToSnakeCase(props)
     return this.resourceRequest({
       url: apiEndpoints.TRANSACTIONS,
+      method: Method.Post,
+      data
+    })
+  }
+
+  // Search Accounts
+  async searchAccounts(
+    props: SearchAccountsBodyProps
+  ): Promise<SearchAccountsResponse> {
+    const { installationId } = props || {}
+    if (!installationId) {
+      throw new IncogniaError('No installationId provided')
+    }
+    const data = convertObjectToSnakeCase(props)
+
+    return this.resourceRequest({
+      url: apiEndpoints.ACCOUNTS,
       method: Method.Post,
       data
     })

--- a/src/types.ts
+++ b/src/types.ts
@@ -269,3 +269,18 @@ export enum FeedbackEvent {
   AccountTakeover = 'account_takeover',
   MposFraud = 'mpos_fraud'
 }
+
+export type SearchAccountsBodyProps = {
+  installationId: string
+}
+
+export type SearchAccountsResponse = {
+  count: number
+  data: Array<AccountData>
+}
+
+type AccountData = {
+  accountId: string
+  firstEventAt: string
+  lastEventAt: string
+}

--- a/test/incogniaApi.test.ts
+++ b/test/incogniaApi.test.ts
@@ -218,6 +218,51 @@ describe('API', () => {
         })
       })
     })
+
+    it('retrieves accounts', async () => {
+      const timestamp = '2022-06-02T22:25:30.885104Z'
+
+      const apiResponse = {
+        count: 2,
+        data: [
+          {
+            account_id: '1',
+            first_event_at: timestamp,
+            last_event_at: timestamp
+          },
+          {
+            account_id: '2',
+            first_event_at: timestamp,
+            last_event_at: timestamp
+          }
+        ]
+      }
+
+      const expectedResponse = {
+        count: 2,
+        data: [
+          {
+            accountId: '1',
+            firstEventAt: timestamp,
+            lastEventAt: timestamp
+          },
+          {
+            accountId: '2',
+            firstEventAt: timestamp,
+            lastEventAt: timestamp
+          }
+        ]
+      }
+
+      nock(BASE_ENDPOINT_URL)
+        .post(`/v2/accounts/search`)
+        .reply(200, apiResponse)
+
+      const accounts = await incogniaApi.searchAccounts({
+        installationId: 'installation_id'
+      })
+      expect(accounts).toEqual(expectedResponse)
+    })
   })
 
   describe('Access token managament', () => {


### PR DESCRIPTION
Adds support to the Accounts API.

```
 incogniaApi
    .searchAccounts({ installationId: "..." })
    .then((value) => console.log(value))
    .catch((error) => console.log(error));
    
    
  // Response 
  {
    count: 1,
    data: [
      {
        accountId: 'low_risk_account_1',
        firstEventAt: '2022-06-02T22:25:26.023296Z',
        lastEventAt: '2022-06-02T22:25:26.023296Z'
      }
    ]
  }
```

If the `installationId` is not passed, an error occurs: `IncogniaError: No installationId provided`