### PR TITLE
Fix import type module in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "repository": "https://github.com/inloco/incognia-node",
   "version": "4.2.0",
   "license": "MIT",
+  "type": "module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
V4.2.0 is not working. You have to explicitly configure package json to be a module in order to works in Node.