### PR TITLE
Add Contributing Guide and Publish to npm Workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish package to npmjs.com
+on:
+  release:
+    types: [published]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch: {}
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
+      - name: publish to npm
+        run: pnpm publish --no-git-checks --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Development
+
+1. Clone the repo:
+
+    ```sh
+    git clone git@github.com:inloco/incognia-node.git
+    ```
+
+2. Install `pnpm`. Follow https://pnpm.io/installation
+
+3. Install deps:
+
+    ```sh
+    cd incognia-node
+    pnpm install
+    ```
+
+4. After making the desired changes, you should remember to update the package version:
+   1. Update the package version in `package.json`
+   2. Update the `version` variable inside the `src/version.ts` file. You can either do it manually or by running:
+
+        ```sh
+        pnpm genVersion
+        ```
+
+# Releases
+
+OBS: Not every merged PR on `main` needs to be released. You might want to release a new version including many PRs.
+
+That said, to release a new version, follow these steps:
+
+1. Go to the releases page (https://github.com/inloco/incognia-node/releases)
+2. Click on "Draft a new release"
+3. On the "Choose a tag" dropdown, write the version you want to release preceded by "v" and create a new tag for it. Ex: you can write `v4.3.2` and click on "Create new tag: v4.3.2". Make sure the tag matches the version you have in your `package.json` file
+4. Make sure the target is set to `master`
+5. In the "Release title" input, type the name of the created tag
+6. Click on "Generate release notes". Edit if needed
+7. Click on "Publish release"
+
+This will automatically push it to npm (See [actions](https://github.com/inloco/incognia-node/actions))


### PR DESCRIPTION
* Adds contributing instructions
* Adds an action for publishing the package to npm on every release (it's the same as [Cosmik's](https://github.com/inloco/cosmik/blob/main/.github/workflows/publish.yml))