### PR TITLE
Fix Secret Name in Publish Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,4 +23,4 @@ jobs:
       - name: publish to npm
         run: pnpm publish --no-git-checks --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.INCOGNIA_NODE_NPM_TOKEN }}


### PR DESCRIPTION
The secret is now called `INCOGNIA_NODE_NPM_TOKEN`, vide [PR](https://github.com/inloco/infra-as-code/pull/2046)