### PR TITLE
Change commonJS extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "5.0.0",
   "license": "MIT",
   "type": "module",
-  "main": "dist/index.cjs.js",
+  "main": "dist/index.cjs",
   "module": "dist/index.es.js",
   "typings": "dist/index.d.ts",
   "files": [
@@ -13,7 +13,7 @@
   ],
   "exports": {
     ".": {
-      "require": "./dist/index.cjs.js",
+      "require": "./dist/index.cjs",
       "import": "./dist/index.es.js"
     }
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,10 @@ export default defineConfig({
     lib: {
       entry: path.resolve(__dirname, 'src/index.ts'),
       formats: ['es', 'cjs'],
-      fileName: format => `index.${format}.js`
+      fileName: format => {
+        if (format === 'cjs') return `index.${format}`
+        return `index.${format}.js`
+      }
     },
     rollupOptions: {
       external: [...Object.keys(dependencies)],


### PR DESCRIPTION
We build this library for ES modules as well as commonJS modules.

The commonJS version should build the files with only `.cjs` extension instead of `.cjs.js`.

Dist folder:
![image](https://github.com/inloco/incognia-node/assets/1139664/00a36a3b-1888-4158-bec6-37f524edca24)
