### PR TITLE
feat: add RFC 3999 fields that replace timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ try {
   incogniaApi.registerFeedback({
     installationId: 'installation_id',
     accountId: 'account_id',
-    event: 'payment_accepted',
-    timestamp: 1610570403068 // milliseconds
+    event: FeedbackEvent.AccountTakeover,
+    occurredAt: '2024-07-22T15:20:00Z'
   })
 } catch (error) {
   console.log(error.message)

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,7 +106,9 @@ export type RegisterFeedbackBodyProps = {
   loginId?: string
   paymentId?: string
   signupId?: string
+  /** @deprecated use occurredAt instead */
   timestamp?: number
+  occurredAt?: Date
   [x: string]: any
 }
 
@@ -130,7 +132,9 @@ export type RegisterTransactionProps = (
 type TransactionLocation = {
   latitude: number
   longitude: number
+  /** @deprecated use collectedAt instead */
   timestamp?: number
+  collectedAt?: Date
 }
 
 type AddressCoordinates = {

--- a/test/formatting.test.ts
+++ b/test/formatting.test.ts
@@ -10,12 +10,14 @@ describe('convertObjectToSnakeCase', () => {
       convertObjectToSnakeCase({
         keyName: { nestedKey: 2 },
         a: [{ nestedInArray: 'black_rice' }],
-        keyNameWithNumber60d: 3
+        keyNameWithNumber60d: 3,
+        keyValueIsDate: new Date('2024-07-17T01:02:03Z')
       })
     ).toEqual({
       key_name: { nested_key: 2 },
       a: [{ nested_in_array: 'black_rice' }],
-      key_name_with_number_60d: 3
+      key_name_with_number_60d: 3,
+      key_value_is_date: '2024-07-17T01:02:03.000Z'
     })
   })
 })

--- a/test/incogniaApi.test.ts
+++ b/test/incogniaApi.test.ts
@@ -262,7 +262,8 @@ describe('API', () => {
             loginId: 'login_id',
             paymentId: 'payment_id',
             signupId: 'signup_id',
-            timestamp: 123
+            timestamp: 123,
+            occurredAt: new Date("Jul 19 2024 01:02:03 UTC"),
           },
           {
             dryRun: true
@@ -276,7 +277,8 @@ describe('API', () => {
           login_id: 'login_id',
           payment_id: 'payment_id',
           signup_id: 'signup_id',
-          timestamp: 123
+          timestamp: 123,
+          occurred_at: '2024-07-19T01:02:03.000Z'
         }
 
         const expectedParams = {


### PR DESCRIPTION
Three fields were added to the API to replace existing `timestamp` fields, two of them are present in this library:
- POST /feedbacks `timestamp` is being replaced by `occurred_at`;
- POST /transactions `location.timestamp` is being replaced by `location.collected_at`.

In these new fields, the date is formatted as a RFC 3339 string, e.g. '2024-07-17T01:02:03Z'. This PR adds the new fields and marks the existing ones as deprecated.
