### PR TITLE
[6.0.0] feat!: remove deprecated timestamp fields

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -108,8 +108,6 @@ export type RegisterFeedbackBodyProps = {
   loginId?: string
   paymentId?: string
   signupId?: string
-  /** @deprecated use occurredAt instead */
-  timestamp?: number
   occurredAt?: Date
   expiresAt?: Date
   [x: string]: any
@@ -135,8 +133,6 @@ export type RegisterTransactionProps = (
 type TransactionLocation = {
   latitude: number
   longitude: number
-  /** @deprecated use collectedAt instead */
-  timestamp?: number
   collectedAt?: Date
 }
 

--- a/test/incogniaApi.test.ts
+++ b/test/incogniaApi.test.ts
@@ -264,7 +264,6 @@ describe('API', () => {
             loginId: 'login_id',
             paymentId: 'payment_id',
             signupId: 'signup_id',
-            timestamp: 123,
             occurredAt: new Date("Jul 19 2024 01:02:03 UTC"),
             expiresAt:  new Date("Jul 30 2024 01:02:03 UTC"),
           },
@@ -282,7 +281,6 @@ describe('API', () => {
           login_id: 'login_id',
           payment_id: 'payment_id',
           signup_id: 'signup_id',
-          timestamp: 123,
           occurred_at: '2024-07-19T01:02:03.000Z',
           expires_at: '2024-07-30T01:02:03.000Z'
         }


### PR DESCRIPTION
This is a breaking change. Will be released together with #85 and the upcoming singleton implementation.