### PR TITLE
[6.0.0] feat(Singleton): implement the API wrapper as a singleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ When migrating to v6, adjust the `IncogniaApi` usage as follows.
 
 Instead of creating an instance of the `IncogniaApi` class using your API credentials, just initialize the `IncogniaApi` with your credentials using the `init()` method. Initializing the `IncogniaApi` is a required step and must be done before calling any of the other `IncogniaApi` methods.
 
-```
+```js
 // Before
 const incogniaApi = new IncogniaApi({
   clientId: 'clientId',
@@ -258,7 +258,7 @@ IncogniaApi.init({
 
 Every method of the `IncogniaApi` instance is now static, and should be called on the `IncogniaApi` class.
 
-```
+```js
 // Before
 const signup = await incogniaApi.registerSignup({...})
 const login = await incogniaApi.registerLogin({...})

--- a/README.md
+++ b/README.md
@@ -232,9 +232,9 @@ try {
 
 ## Migration to v6
 
-The v6 has brought many changes to the `IncogniaApi` interface, transforming the previous instance methods into static methods.
+The v6 changed the `IncogniaApi` interface, transforming the previous instance methods into static methods.
 
-When migrating to v6, it'll be necessary to adjust the `IncogniaApi` usage as follows.
+When migrating to v6, adjust the `IncogniaApi` usage as follows.
 
 ### Initialization
 
@@ -256,7 +256,7 @@ IncogniaApi.init({
 
 ### Register methods
 
-Every method that was called on a `IncogniaApi` instance is now static, and should be called on the `IncogniaApi` class.
+Every method of the `IncogniaApi` instance is now static, and should be called on the `IncogniaApi` class.
 
 ```
 // Before

--- a/README.md
+++ b/README.md
@@ -23,19 +23,21 @@ yarn add @incognia/api
 Require the package:
 
 CommonJS modules:
+
 ```js
 const { IncogniaApi } = require('@incognia/api')
 ```
 
 Or ES modules:
+
 ```js
-import { IncogniaApi } from "@incognia/api";
+import { IncogniaApi } from '@incognia/api'
 ```
 
-Instantiate with your clientId and clientSecret:
+Initialize the `IncogniaApi` with your `clientId` and `clientSecret`. This is a required step and must be done before calling any of the API methods.
 
 ```js
-const incogniaApi = new IncogniaApi({
+IncogniaApi.init({
   clientId: 'clientId',
   clientSecret: 'clientSecret'
 })
@@ -49,7 +51,7 @@ This method registers a new mobile signup for the given installation and address
 
 ```js
 try {
-  const signup = await incogniaApi.registerSignup({
+  const signup = await IncogniaApi.registerSignup({
     installationId: 'installation_id',
     structuredAddress: {
       locale: 'en-US',
@@ -76,8 +78,8 @@ This method registers a new web signup for the given session token, returning a 
 
 ```js
 try {
-  const signup = await incogniaApi.registerWebSignup({
-    sessionToken: 'session_token',
+  const signup = await IncogniaApi.registerWebSignup({
+    sessionToken: 'session_token'
   })
 } catch (error) {
   console.log(error.message)
@@ -90,7 +92,7 @@ This method registers a new mobile login for the given installation and account,
 
 ```js
 try {
-  const login = await incogniaApi.registerLogin({
+  const login = await IncogniaApi.registerLogin({
     installationId: 'installation_id',
     accountId: 'account_id',
     externalId: 'external_id' // optional field
@@ -106,15 +108,14 @@ This method registers a new web login for the given session token and account, r
 
 ```js
 try {
-  const login = await incogniaApi.registerWebLogin({
+  const login = await IncogniaApi.registerWebLogin({
     sessionToken: 'session_token',
-    accountId: 'account_id',
+    accountId: 'account_id'
   })
 } catch (error) {
   console.log(error.message)
 }
 ```
-
 
 ### Registering a Payment
 
@@ -122,7 +123,7 @@ This method registers a new payment for the given installation and account, retu
 
 ```js
 try {
-  const payment = await incogniaApi.registerPayment({
+  const payment = await IncogniaApi.registerPayment({
     installationId: 'installation_id',
     accountId: 'account_id',
     addresses: [
@@ -159,7 +160,7 @@ This method registers a new web payment for the given session token and account,
 
 ```js
 try {
-  const payment = await incogniaApi.registerWebPayment({
+  const payment = await IncogniaApi.registerWebPayment({
     sessionToken: 'session_token',
     accountId: 'account_id'
   })
@@ -174,7 +175,7 @@ This method registers a feedback event for the given identifiers related to a si
 
 ```js
 try {
-  incogniaApi.registerFeedback({
+  IncogniaApi.registerFeedback({
     installationId: 'installation_id',
     accountId: 'account_id',
     event: FeedbackEvent.AccountTakeover,
@@ -217,7 +218,7 @@ Every method call can throw `IncogniaApiError` and `IncogniaError`.
 const { IncogniaApi, IncogniaApiError } = require('@incognia/api')
 
 try {
-  const loginAssessment = await incogniaApi.registerLogin({
+  const loginAssessment = await IncogniaApi.registerLogin({
     installationId: 'installation_id',
     accountId: 'account_id'
   })
@@ -227,6 +228,48 @@ try {
     console.log(error.payload)
   }
 }
+```
+
+## Migration to v6
+
+The v6 has brought many changes to the `IncogniaApi` interface, transforming the previous instance methods into static methods.
+
+When migrating to v6, it'll be necessary to adjust the `IncogniaApi` usage as follows.
+
+### Initialization
+
+Instead of creating an instance of the `IncogniaApi` class using your API credentials, just initialize the `IncogniaApi` with your credentials using the `init()` method. Initializing the `IncogniaApi` is a required step and must be done before calling any of the other `IncogniaApi` methods.
+
+```
+// Before
+const incogniaApi = new IncogniaApi({
+  clientId: 'clientId',
+  clientSecret: 'clientSecret'
+})
+
+// After
+IncogniaApi.init({
+  clientId: 'clientId',
+  clientSecret: 'clientSecret'
+})
+```
+
+### Register methods
+
+Every method that was called on a `IncogniaApi` instance is now static, and should be called on the `IncogniaApi` class.
+
+```
+// Before
+const signup = await incogniaApi.registerSignup({...})
+const login = await incogniaApi.registerLogin({...})
+const payment = await incogniaApi.registerPayment({...})
+incogniaApi.registerFeedback({...})
+
+// After
+const signup = await IncogniaApi.registerSignup({...})
+const login = await IncogniaApi.registerLogin({...})
+const payment = await IncogniaApi.registerPayment({...})
+IncogniaApi.registerFeedback({...})
 ```
 
 ## More documentation

--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -5,7 +5,7 @@ type ApiEndpoints = {
   FEEDBACKS: string
 }
 
-const BASE_ENDPOINT = 'https://api.incognia.com/api'
+export const BASE_ENDPOINT = 'https://api.incognia.com/api'
 
 export const apiEndpoints: ApiEndpoints = {
   TOKEN: `${BASE_ENDPOINT}/v2/token`,

--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -1,0 +1,15 @@
+type ApiEndpoints = {
+  TOKEN: string
+  SIGNUPS: string
+  TRANSACTIONS: string
+  FEEDBACKS: string
+}
+
+const BASE_ENDPOINT = 'https://api.incognia.com/api'
+
+export const apiEndpoints: ApiEndpoints = {
+  TOKEN: `${BASE_ENDPOINT}/v2/token`,
+  SIGNUPS: `${BASE_ENDPOINT}/v2/onboarding/signups`,
+  TRANSACTIONS: `${BASE_ENDPOINT}/v2/authentication/transactions`,
+  FEEDBACKS: `${BASE_ENDPOINT}/v2/feedbacks`
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-export { IncogniaApi, apiEndpoints } from './incogniaApi'
+export { IncogniaApi } from './incogniaApi'
+export { apiEndpoints } from './endpoints'
 export {
   CouponType,
   FeedbackEvent,

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,0 +1,24 @@
+import { CustomRequestError, throwCustomRequestError } from './errors'
+import { convertObjectToCamelCase } from './formatting'
+import { buildUserAgent } from './utils'
+import axios, { AxiosRequestConfig } from 'axios'
+import { IncogniaToken } from './token'
+
+export async function requestResource(
+  options: AxiosRequestConfig,
+  token: IncogniaToken | null
+) {
+  try {
+    const response = await axios({
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        'User-Agent': buildUserAgent(),
+        Authorization: `${token?.tokenType} ${token?.accessToken}`
+      }
+    })
+    return convertObjectToCamelCase(response.data)
+  } catch (e: unknown) {
+    throwCustomRequestError(e as CustomRequestError)
+  }
+}

--- a/src/token.ts
+++ b/src/token.ts
@@ -1,0 +1,85 @@
+import qs from 'qs'
+import axios from 'axios'
+import { apiEndpoints } from './endpoints'
+import { Method } from './types'
+import { CustomRequestError, throwCustomRequestError } from './errors'
+import { buildUserAgent } from './utils'
+
+export type IncogniaToken = {
+  createdAt: number
+  expiresIn: number
+  accessToken: string
+  tokenType: string
+}
+
+type IncogniaApiConstructor = {
+  clientId: string
+  clientSecret: string
+}
+
+export class TokenManager {
+  readonly clientId: string
+  readonly clientSecret: string
+  incogniaToken: IncogniaToken | null
+
+  constructor({ clientId, clientSecret }: IncogniaApiConstructor) {
+    this.clientId = clientId
+    this.clientSecret = clientSecret
+    this.incogniaToken = null
+  }
+
+  async getToken() {
+    await this.updateAccessToken()
+    return this.incogniaToken
+  }
+
+  async updateAccessToken() {
+    if (this.isAccessTokenValid()) return
+
+    const axiosResponse = await this.requestToken()
+    const data = axiosResponse?.data
+
+    this.incogniaToken = {
+      createdAt: Math.round(Date.now() / 1000),
+      expiresIn: parseInt(data.expires_in),
+      accessToken: data.access_token,
+      tokenType: data.token_type
+    }
+  }
+
+  isAccessTokenValid() {
+    if (!this.incogniaToken) return false
+
+    const createdAt = this.incogniaToken.createdAt
+    const expiresIn = this.incogniaToken.expiresIn
+
+    const expirationLimit = createdAt + expiresIn
+    const nowInSeconds = Math.round(Date.now() / 1000)
+
+    if (expirationLimit <= nowInSeconds) {
+      return false
+    }
+
+    return true
+  }
+
+  async requestToken() {
+    try {
+      return await axios({
+        method: Method.Post,
+        url: apiEndpoints.TOKEN,
+        data: qs.stringify({ grant_type: 'client_credentials' }),
+        auth: {
+          username: this.clientId,
+          password: this.clientSecret
+        },
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'User-Agent': buildUserAgent()
+        }
+      })
+    } catch (e: unknown) {
+      throwCustomRequestError(e as CustomRequestError)
+    }
+  }
+}

--- a/test/incogniaApi.test.ts
+++ b/test/incogniaApi.test.ts
@@ -1,8 +1,7 @@
 import nock from 'nock'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { CouponType, FeedbackEvent, IncogniaApi } from '../src/'
-
-const BASE_ENDPOINT_URL = 'https://api.incognia.com/api'
+import { BASE_ENDPOINT } from '../src/endpoints'
 
 const credentials = {
   clientId: 'clientId',
@@ -64,7 +63,7 @@ describe('Incognia API', () => {
   describe('when the API is initialized', () => {
     beforeEach(() => {
       IncogniaApi.init(credentials)
-      nock(BASE_ENDPOINT_URL).post('/v2/token').reply(200, accessTokenExample)
+      nock(BASE_ENDPOINT).post('/v2/token').reply(200, accessTokenExample)
     })
 
     it('validates signup', async () => {
@@ -88,9 +87,7 @@ describe('Incognia API', () => {
         signupAttemptsByDeviceTotal10d: 5
       }
 
-      nock(BASE_ENDPOINT_URL)
-        .post(`/v2/onboarding/signups`)
-        .reply(200, apiResponse)
+      nock(BASE_ENDPOINT).post(`/v2/onboarding/signups`).reply(200, apiResponse)
 
       const signup = await IncogniaApi.registerSignup({
         installationId: 'installation_id',
@@ -131,7 +128,7 @@ describe('Incognia API', () => {
 
       const sessionToken = 'session_token'
 
-      nock(BASE_ENDPOINT_URL)
+      nock(BASE_ENDPOINT)
         .post(`/v2/onboarding/signups`, {
           session_token: sessionToken
         })
@@ -173,7 +170,7 @@ describe('Incognia API', () => {
         }
       }
 
-      nock(BASE_ENDPOINT_URL)
+      nock(BASE_ENDPOINT)
         .post(`/v2/authentication/transactions`)
         .reply(200, apiResponse)
 
@@ -204,7 +201,7 @@ describe('Incognia API', () => {
         riskAssessment: 'low_risk'
       }
 
-      nock(BASE_ENDPOINT_URL)
+      nock(BASE_ENDPOINT)
         .post(`/v2/authentication/transactions`)
         .reply(200, apiResponse)
 
@@ -235,7 +232,7 @@ describe('Incognia API', () => {
         riskAssessment: 'low_risk'
       }
 
-      nock(BASE_ENDPOINT_URL)
+      nock(BASE_ENDPOINT)
         .post(`/v2/authentication/transactions`)
         .reply(200, apiResponse)
 
@@ -269,7 +266,7 @@ describe('Incognia API', () => {
         riskAssessment: 'low_risk'
       }
 
-      nock(BASE_ENDPOINT_URL)
+      nock(BASE_ENDPOINT)
         .post(`/v2/authentication/transactions`)
         .reply(200, apiResponse)
 
@@ -290,7 +287,7 @@ describe('Incognia API', () => {
       it('registers feedback when all required params are filled', async () => {
         const apiResponse = {}
 
-        nock(BASE_ENDPOINT_URL)
+        nock(BASE_ENDPOINT)
           .post(`/v2/feedbacks?dry_run=true`)
           .reply(200, apiResponse)
 
@@ -309,7 +306,7 @@ describe('Incognia API', () => {
       it('registers feedback when all params are filled', async () => {
         const apiResponse = {}
 
-        nock(BASE_ENDPOINT_URL).post(`/v2/feedbacks`).reply(200, apiResponse)
+        nock(BASE_ENDPOINT).post(`/v2/feedbacks`).reply(200, apiResponse)
 
         expect(
           IncogniaApi.registerFeedback({

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -2,8 +2,7 @@ import nock from 'nock'
 import { IncogniaApiError } from '../src'
 import { describe, expect, it } from 'vitest'
 import { requestResource } from '../src/request'
-
-const BASE_ENDPOINT_URL = 'https://api.incognia.com/api'
+import { BASE_ENDPOINT } from '../src/endpoints'
 
 const token = {
   createdAt: Date.now().valueOf(),
@@ -17,7 +16,7 @@ describe('requestResource', () => {
     it('informs Authorization header when requesting resource', async () => {
       const expectedAuthorizationHeader = `${token.tokenType} ${token.accessToken}`
 
-      const resourceRequest = nock(BASE_ENDPOINT_URL, {
+      const resourceRequest = nock(BASE_ENDPOINT, {
         reqheaders: {
           'Content-Type': 'application/json',
           Authorization: expectedAuthorizationHeader
@@ -28,7 +27,7 @@ describe('requestResource', () => {
 
       await requestResource(
         {
-          url: `${BASE_ENDPOINT_URL}/someUrl`,
+          url: `${BASE_ENDPOINT}/someUrl`,
           method: 'get'
         },
         token
@@ -39,7 +38,7 @@ describe('requestResource', () => {
 
     describe('and the request fails', () => {
       it('throws Incognia errors', async () => {
-        nock(BASE_ENDPOINT_URL).get('/someUrl').replyWithError({
+        nock(BASE_ENDPOINT).get('/someUrl').replyWithError({
           message: 'something awful happened',
           code: 'AWFUL_ERROR'
         })
@@ -47,7 +46,7 @@ describe('requestResource', () => {
         const dispatchRequest = async () => {
           await requestResource(
             {
-              url: `${BASE_ENDPOINT_URL}/someUrl`,
+              url: `${BASE_ENDPOINT}/someUrl`,
               method: 'get'
             },
             token

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -1,0 +1,61 @@
+import nock from 'nock'
+import { IncogniaApiError } from '../src'
+import { describe, expect, it } from 'vitest'
+import { requestResource } from '../src/request'
+
+const BASE_ENDPOINT_URL = 'https://api.incognia.com/api'
+
+const token = {
+  createdAt: Date.now().valueOf(),
+  expiresIn: 20 * 60,
+  accessToken: 'access_token',
+  tokenType: 'Bearer'
+}
+
+describe('requestResource', () => {
+  describe('when requesting a resource', () => {
+    it('informs Authorization header when requesting resource', async () => {
+      const expectedAuthorizationHeader = `${token.tokenType} ${token.accessToken}`
+
+      const resourceRequest = nock(BASE_ENDPOINT_URL, {
+        reqheaders: {
+          'Content-Type': 'application/json',
+          Authorization: expectedAuthorizationHeader
+        }
+      })
+        .get(`/someUrl`)
+        .reply(200, {})
+
+      await requestResource(
+        {
+          url: `${BASE_ENDPOINT_URL}/someUrl`,
+          method: 'get'
+        },
+        token
+      )
+
+      expect(resourceRequest.isDone()).toBeTruthy()
+    })
+
+    describe('and the request fails', () => {
+      it('throws Incognia errors', async () => {
+        nock(BASE_ENDPOINT_URL).get('/someUrl').replyWithError({
+          message: 'something awful happened',
+          code: 'AWFUL_ERROR'
+        })
+
+        const dispatchRequest = async () => {
+          await requestResource(
+            {
+              url: `${BASE_ENDPOINT_URL}/someUrl`,
+              method: 'get'
+            },
+            token
+          )
+        }
+
+        await expect(dispatchRequest).rejects.toThrowError(IncogniaApiError)
+      })
+    })
+  })
+})

--- a/test/token.test.ts
+++ b/test/token.test.ts
@@ -1,0 +1,105 @@
+import nock from 'nock'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { IncogniaApiError } from '../src/'
+import { TokenManager } from '../src/token'
+
+const BASE_ENDPOINT_URL = 'https://api.incognia.com/api'
+
+const credentials = {
+  clientId: 'clientId',
+  clientSecret: 'clientSecret'
+}
+
+const accessTokenExample = {
+  access_token: 'access_token',
+  expires_in: 20 * 60,
+  token_type: 'Bearer'
+}
+
+describe('Access token managament', () => {
+  let tokenManager: TokenManager
+
+  beforeEach(() => {
+    tokenManager = new TokenManager(credentials)
+  })
+
+  describe('when requesting a token ', () => {
+    it('calls access token endpoint with creds', async () => {
+      nock(BASE_ENDPOINT_URL).post(`/v2/feedbacks`).reply(200, {})
+      const accessTokenEndpointCall = nock(BASE_ENDPOINT_URL, {
+        reqheaders: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        }
+      })
+        .post('/v2/token', { grant_type: 'client_credentials' })
+        .basicAuth({
+          user: credentials.clientId,
+          pass: credentials.clientSecret
+        })
+        .reply(200, accessTokenExample)
+
+      await tokenManager.requestToken()
+      expect(accessTokenEndpointCall.isDone()).toBeTruthy()
+    })
+
+    describe('and the request fails', () => {
+      it('throws Incognia errors', async () => {
+        nock(BASE_ENDPOINT_URL).post('/v2/token').replyWithError({
+          message: 'something awful happened',
+          code: 'AWFUL_ERROR'
+        })
+
+        const dispatchRequest = async () => {
+          await tokenManager.requestToken()
+        }
+
+        await expect(dispatchRequest).rejects.toThrowError(IncogniaApiError)
+      })
+    })
+  })
+
+  describe('when getting the token', () => {
+    it('calls access token endpoint only at the first time', async () => {
+      const accessTokenEndpointFirstCall = nock(BASE_ENDPOINT_URL)
+        .post('/v2/token')
+        .reply(200, accessTokenExample)
+      const accessTokenEndpointSecondCall = nock(BASE_ENDPOINT_URL)
+        .post('/v2/token')
+        .reply(200, accessTokenExample)
+
+      //call resource for the first time
+      await tokenManager.getToken()
+      expect(accessTokenEndpointFirstCall.isDone()).toBeTruthy()
+
+      //call resource for the second time
+      await tokenManager.getToken()
+      expect(accessTokenEndpointSecondCall.isDone()).toBeFalsy()
+    })
+  })
+
+  describe('accessToken validation', () => {
+    it('returns true if the token is valid', async () => {
+      nock(BASE_ENDPOINT_URL).post('/v2/token').reply(200, accessTokenExample)
+      await tokenManager.updateAccessToken()
+      expect(tokenManager.isAccessTokenValid()).toEqual(true)
+    })
+
+    it('returns false if the token is expired', async () => {
+      nock(BASE_ENDPOINT_URL).post('/v2/token').reply(200, accessTokenExample)
+
+      Date.now = vi.fn(() => new Date(Date.UTC(2021, 3, 14)).valueOf())
+      await tokenManager.updateAccessToken()
+      Date.now = vi.fn(() => {
+        const date = new Date(Date.UTC(2021, 3, 14))
+        date.setUTCSeconds(accessTokenExample.expires_in)
+
+        return date.valueOf()
+      })
+      expect(tokenManager.isAccessTokenValid()).toEqual(false)
+    })
+
+    it('returns false if there is no token', async () => {
+      expect(tokenManager.isAccessTokenValid()).toEqual(false)
+    })
+  })
+})


### PR DESCRIPTION
Esse PR modifica a classe `IncogniaApi` para usar um singleton e ter métodos estáticos. 

Por limitar o acesso à instância, tive que refatorar a classe para extrair as lógicas de gestão de token e de request para arquivos próprios, permitindo que essa lógica fosse testada direitinho.

O novo uso vai ficar assim:

```
import { IncogniaApi } from '@incognia/api'

IncogniaApi.init({
  clientId: 'clientId',
  clientSecret: 'clientSecret'
})

const signup = await IncogniaApi.registerSignup({
  installationId: 'installation_id',
  ...
})
```

Essa mudança é quebrante, e o release deve ser feito em um major release na `v6.0.0`.