### PR TITLE
[6.0.0] feat: make the policy_id a required field

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This method registers a new mobile signup for the given request token and addres
 try {
   const signup = await IncogniaApi.registerSignup({
     requestToken: 'request_token',
+    policyId: 'policy_id',
     structuredAddress: {
       locale: 'en-US',
       countryName: 'United States of America',
@@ -79,7 +80,8 @@ This method registers a new web signup for the given request token, returning a 
 ```js
 try {
   const signup = await IncogniaApi.registerWebSignup({
-    requestToken: 'request_token'
+    requestToken: 'request_token',
+    policyId: 'policy_id'
   })
 } catch (error) {
   console.log(error.message)
@@ -95,6 +97,7 @@ try {
   const login = await IncogniaApi.registerLogin({
     requestToken: 'request_token',
     accountId: 'account_id',
+    policyId: 'policy_id',
     externalId: 'external_id' // optional field
   })
 } catch (error) {
@@ -110,7 +113,8 @@ This method registers a new web login for the given request token and account, r
 try {
   const login = await IncogniaApi.registerWebLogin({
     requestToken: 'request_token',
-    accountId: 'account_id'
+    accountId: 'account_id',
+    policyId: 'policy_id'
   })
 } catch (error) {
   console.log(error.message)
@@ -126,6 +130,7 @@ try {
   const payment = await IncogniaApi.registerPayment({
     requestToken: 'request_token',
     accountId: 'account_id',
+    policyId: 'policy_id',
     addresses: [
       {
         structuredAddress: {
@@ -162,7 +167,8 @@ This method registers a new web payment for the given request token and account,
 try {
   const payment = await IncogniaApi.registerWebPayment({
     requestToken: 'request_token',
-    accountId: 'account_id'
+    accountId: 'account_id',
+    policyId: 'policy_id'
   })
 } catch (error) {
   console.log(error.message)
@@ -272,7 +278,7 @@ const payment = await IncogniaApi.registerPayment({...})
 IncogniaApi.registerFeedback({...})
 ```
 
-Furthermore, the `installationId` and `sessionToken` parameters were removed, and `requestToken` should be used instead. The `requestToken` field can receive the previous `installationId` and `sessionToken` values, as well as the new `requestToken` value from the Mobile and Web SDKs.
+Furthermore, the `installationId` and `sessionToken` parameters were removed, and `requestToken` should be used instead. The `requestToken` field can receive the previous `installationId` and `sessionToken` values, as well as the new `requestToken` value from the Mobile and Web SDKs. Also, the `policyId` is now a required parameter and must be used on every assessment.
 
 ```js
 // Before
@@ -288,11 +294,13 @@ const webPaymentAssessment = await incogniaApi.registerWebPayment({
 // After
 const loginAssessment = await IncogniaApi.registerLogin({
   requestToken: 'installation_id',
-  accountId: 'account_id'
+  accountId: 'account_id',
+  policyId: 'policy_id'
 })
 const webPaymentAssessment = await IncogniaApi.registerWebPayment({
   requestToken: 'session_token',
-  accountId: 'account_id'
+  accountId: 'account_id',
+  policyId: 'policy_id'
 })
 ```
 

--- a/src/incogniaApi.ts
+++ b/src/incogniaApi.ts
@@ -31,6 +31,7 @@ const errorMessages = {
   CLIENT_SECRET: 'Missing required parameter: clientSecret',
   REQUEST_TOKEN: 'Missing required parameter: requestToken',
   ACCOUNT_ID: 'Missing required parameter: accountId',
+  POLICY_ID: 'Missing required parameter: policyId',
   EVENT: 'Missing required parameter: event',
   INIT: 'IncogniaApi not initialized'
 }
@@ -68,9 +69,10 @@ export class IncogniaApi {
   public static async registerSignup(
     props: RegisterSignupProps
   ): Promise<SignupResponse> {
-    const { requestToken } = props || {}
+    const { requestToken, policyId } = props || {}
     if (!IncogniaApi.instance) throw new IncogniaError(errorMessages.INIT)
     if (!requestToken) throw new IncogniaError(errorMessages.REQUEST_TOKEN)
+    if (!policyId) throw new IncogniaError(errorMessages.POLICY_ID)
 
     return IncogniaApi.instance.#registerSignup(props)
   }
@@ -78,9 +80,10 @@ export class IncogniaApi {
   public static async registerWebSignup(
     props: RegisterWebSignupProps
   ): Promise<WebSignupResponse> {
-    const { requestToken } = props || {}
+    const { requestToken, policyId } = props || {}
     if (!IncogniaApi.instance) throw new IncogniaError(errorMessages.INIT)
     if (!requestToken) throw new IncogniaError(errorMessages.REQUEST_TOKEN)
+    if (!policyId) throw new IncogniaError(errorMessages.POLICY_ID)
 
     return IncogniaApi.instance.#registerSignup(props)
   }
@@ -88,10 +91,11 @@ export class IncogniaApi {
   public static async registerLogin(
     props: RegisterLoginProps
   ): Promise<TransactionResponse> {
-    const { requestToken, accountId } = props || {}
+    const { requestToken, accountId, policyId } = props || {}
     if (!IncogniaApi.instance) throw new IncogniaError(errorMessages.INIT)
     if (!requestToken) throw new IncogniaError(errorMessages.REQUEST_TOKEN)
     if (!accountId) throw new IncogniaError(errorMessages.ACCOUNT_ID)
+    if (!policyId) throw new IncogniaError(errorMessages.POLICY_ID)
 
     return IncogniaApi.instance.#registerTransaction({
       ...props,
@@ -102,10 +106,11 @@ export class IncogniaApi {
   public static async registerWebLogin(
     props: RegisterWebLoginProps
   ): Promise<WebTransactionResponse> {
-    const { requestToken, accountId } = props || {}
+    const { requestToken, accountId, policyId } = props || {}
     if (!IncogniaApi.instance) throw new IncogniaError(errorMessages.INIT)
     if (!requestToken) throw new IncogniaError(errorMessages.REQUEST_TOKEN)
     if (!accountId) throw new IncogniaError(errorMessages.ACCOUNT_ID)
+    if (!policyId) throw new IncogniaError(errorMessages.POLICY_ID)
 
     return IncogniaApi.instance.#registerTransaction({
       ...props,
@@ -116,10 +121,11 @@ export class IncogniaApi {
   public static async registerPayment(
     props: RegisterPaymentProps
   ): Promise<TransactionResponse> {
-    const { requestToken, accountId } = props || {}
+    const { requestToken, accountId, policyId } = props || {}
     if (!IncogniaApi.instance) throw new IncogniaError(errorMessages.INIT)
     if (!requestToken) throw new IncogniaError(errorMessages.REQUEST_TOKEN)
     if (!accountId) throw new IncogniaError(errorMessages.ACCOUNT_ID)
+    if (!policyId) throw new IncogniaError(errorMessages.POLICY_ID)
 
     return IncogniaApi.instance.#registerTransaction({
       ...props,
@@ -130,10 +136,11 @@ export class IncogniaApi {
   public static async registerWebPayment(
     props: RegisterWebPaymentProps
   ): Promise<WebTransactionResponse> {
-    const { requestToken, accountId } = props || {}
+    const { requestToken, accountId, policyId } = props || {}
     if (!IncogniaApi.instance) throw new IncogniaError(errorMessages.INIT)
     if (!requestToken) throw new IncogniaError(errorMessages.REQUEST_TOKEN)
     if (!accountId) throw new IncogniaError(errorMessages.ACCOUNT_ID)
+    if (!policyId) throw new IncogniaError(errorMessages.POLICY_ID)
 
     return IncogniaApi.instance.#registerTransaction({
       ...props,

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,8 +11,8 @@ export enum TransactionAddressType {
 
 export type RegisterSignupBaseProps = {
   requestToken: string
+  policyId: string
   accountId?: string
-  policyId?: string
   [x: string]: any
 }
 
@@ -46,8 +46,8 @@ export type WebSignupEvidenceSummary = WebEvidenceSummary
 
 type RegisterLoginBaseProps = {
   requestToken: string
+  policyId: string
   accountId: string
-  policyId?: string
   [x: string]: any
 }
 
@@ -63,8 +63,8 @@ export type RegisterWebLoginProps = RegisterLoginBaseProps
 
 export type RegisterPaymentBaseProps = {
   requestToken: string
+  policyId: string
   accountId: string
-  policyId?: string
   externalId?: string
   addresses?: Array<TransactionAddress>
   paymentValue?: PaymentValue

--- a/test/incogniaApi.test.ts
+++ b/test/incogniaApi.test.ts
@@ -32,6 +32,7 @@ describe('Incognia API', () => {
       const props = {
         accountId: 'id',
         requestToken: 'id',
+        policyId: 'id',
         event: FeedbackEvent.AccountTakeover
       }
 
@@ -66,9 +67,12 @@ describe('Incognia API', () => {
     })
 
     it('validates signup', async () => {
-      expect(() => IncogniaApi.registerSignup({} as any)).rejects.toThrow(
-        'Missing required parameter: requestToken'
-      )
+      expect(() =>
+        IncogniaApi.registerSignup({ policyId: 'id' } as any)
+      ).rejects.toThrow('Missing required parameter: requestToken')
+      expect(() =>
+        IncogniaApi.registerSignup({ requestToken: 'id' } as any)
+      ).rejects.toThrow('Missing required parameter: policyId')
     })
 
     it('registers signup', async () => {
@@ -109,9 +113,12 @@ describe('Incognia API', () => {
     })
 
     it('validates a web signup', async () => {
-      expect(() => IncogniaApi.registerWebSignup({} as any)).rejects.toThrow(
-        'Missing required parameter: requestToken'
-      )
+      expect(() =>
+        IncogniaApi.registerWebSignup({ policyId: 'id' } as any)
+      ).rejects.toThrow('Missing required parameter: requestToken')
+      expect(() =>
+        IncogniaApi.registerWebSignup({ requestToken: 'token' } as any)
+      ).rejects.toThrow('Missing required parameter: policyId')
     })
 
     it('registers a web signup', async () => {
@@ -129,12 +136,14 @@ describe('Incognia API', () => {
 
       nock(BASE_ENDPOINT)
         .post(`/v2/onboarding/signups`, {
-          request_token: requestToken
+          request_token: requestToken,
+          policy_id: 'policy_id'
         })
         .reply(200, apiResponse)
 
       const webSignup = await IncogniaApi.registerWebSignup({
-        requestToken
+        requestToken,
+        policyId: 'policy_id'
       })
       expect(webSignup).toEqual(expectedResponse)
     })
@@ -175,7 +184,8 @@ describe('Incognia API', () => {
 
       const login = await IncogniaApi.registerLogin({
         requestToken: 'request_token',
-        accountId: 'account_id'
+        accountId: 'account_id',
+        policyId: 'policy_id'
       })
       expect(login).toEqual(expectedResponse)
     })
@@ -187,6 +197,12 @@ describe('Incognia API', () => {
       expect(() =>
         IncogniaApi.registerWebLogin({ requestToken: 'token' } as any)
       ).rejects.toThrow('Missing required parameter: accountId')
+      expect(() =>
+        IncogniaApi.registerWebLogin({
+          accountId: 'id',
+          requestToken: 'token'
+        } as any)
+      ).rejects.toThrow('Missing required parameter: policyId')
     })
 
     it('registers a web login', async () => {
@@ -206,7 +222,8 @@ describe('Incognia API', () => {
 
       const webLogin = await IncogniaApi.registerWebLogin({
         requestToken: 'request_token',
-        accountId: 'account_id'
+        accountId: 'account_id',
+        policyId: 'policy_id'
       })
       expect(webLogin).toEqual(expectedResponse)
     })
@@ -218,6 +235,12 @@ describe('Incognia API', () => {
       expect(() =>
         IncogniaApi.registerPayment({ requestToken: 'token' } as any)
       ).rejects.toThrow('Missing required parameter: accountId')
+      expect(() =>
+        IncogniaApi.registerPayment({
+          accountId: 'id',
+          requestToken: 'token'
+        } as any)
+      ).rejects.toThrow('Missing required parameter: policyId')
     })
 
     it('registers payment', async () => {
@@ -240,6 +263,7 @@ describe('Incognia API', () => {
         accountId: 'account_id',
         appId: 'app_id',
         externalId: 'external_id',
+        policyId: 'policy_id',
         coupon: { type: CouponType.FixedValue, value: 10 }
       })
       expect(payment).toEqual(expectedResponse)
@@ -252,6 +276,12 @@ describe('Incognia API', () => {
       expect(() =>
         IncogniaApi.registerWebPayment({ requestToken: 'token' } as any)
       ).rejects.toThrow('Missing required parameter: accountId')
+      expect(() =>
+        IncogniaApi.registerWebPayment({
+          accountId: 'id',
+          requestToken: 'token'
+        } as any)
+      ).rejects.toThrow('Missing required parameter: policyId')
     })
 
     it('registers a web payment', async () => {
@@ -271,7 +301,8 @@ describe('Incognia API', () => {
 
       const webPayment = await IncogniaApi.registerWebPayment({
         requestToken: 'request_token',
-        accountId: 'account_id'
+        accountId: 'account_id',
+        policyId: 'policy_id'
       })
       expect(webPayment).toEqual(expectedResponse)
     })


### PR DESCRIPTION
Esse PR modifica o `policyId` para ser um campo obrigatório das chamadas à API. 

Essa é uma breaking change que só vai entrar na próxima versão major.