### PR TITLE
Update continuous.yml

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node: ['16.x', '18.x']
+        node: ['16.x', '18.x', '20.x', '22.x']
         os: [ubuntu-latest, macOS-latest]
 
     steps:


### PR DESCRIPTION
Our current build only checks the library using node v16 and v18. Since both versions are already deprecated, I added the v20 and v22 checks.