### PR TITLE
chore(build): externalize-node-builtins

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -7,7 +7,7 @@ import { Method } from './types'
 import { apiEndpoints } from './endpoints'
 import QueryString from 'qs'
 import { TokenStorage } from './token'
-import https from 'https'
+import https from 'node:https'
 
 type RequestManagerConstructor = {
   clientId: string

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,12 @@ import path from 'path'
 import { defineConfig } from 'vite'
 import dts from 'vite-plugin-dts'
 import { dependencies } from './package.json'
+import { builtinModules } from 'module'
+
+const nodeBuiltins = [
+  ...builtinModules,
+  ...builtinModules.map(m => `node:${m}`)
+]
 
 export default defineConfig({
   plugins: [
@@ -19,10 +25,11 @@ export default defineConfig({
       }
     },
     rollupOptions: {
-      external: [...Object.keys(dependencies)],
+      external: [...Object.keys(dependencies), ...nodeBuiltins],
       output: {
         preserveModules: true,
-        exports: 'named'
+        exports: 'named',
+        interop: 'auto'
       }
     },
     target: 'esnext',


### PR DESCRIPTION
When building with vite, vite is turning the Node builtin into an interop’d default import (or a browser polyfill), so https.Agent isn’t the real Node class anymore.

Without this change, the build generates an error in a script usage.

```
> node ./test.js

TypeError: h.default.Agent is not a constructor
```

By externalizing, the node builtins are kept intact.