### PR TITLE
Feat/add bank account info

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,8 @@ export type RegisterPaymentBaseProps = {
   policyId: string
   accountId: string
   personId?: PersonId
+  debtorAccount?: BankAccountInfo
+  creditorAccount?: BankAccountInfo
   storeId?: string
   externalId?: string
   addresses?: Array<TransactionAddress>
@@ -466,6 +468,24 @@ type PaymentMethod = {
 type PersonId = {
   type: string
   value: string
+}
+
+type PixKey = {
+  type: string
+  value: string
+}
+
+export type BankAccountInfo = {
+  accountType?: string
+  accountPurpose?: string
+  holderType?: string
+  holderTaxId?: PersonId
+  country?: string
+  ispbCode?: string
+  branchCode?: string
+  accountNumber?: string
+  accountCheckDigit?: string
+  pixKeys?: Array<PixKey>
 }
 
 export enum FeedbackEvent {

--- a/test/incogniaApi.test.ts
+++ b/test/incogniaApi.test.ts
@@ -1,7 +1,7 @@
 import nock from 'nock'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { CouponType, FeedbackEvent, IncogniaApi } from '../src/'
-import { TransactionLocation } from '../src/types'
+import { BankAccountInfo, TransactionLocation } from '../src/types'
 import { BASE_ENDPOINT } from '../src/endpoints'
 
 const credentials = {
@@ -330,6 +330,25 @@ describe('Incognia API', () => {
         .post(`/v2/authentication/transactions`)
         .reply(200, apiResponse)
 
+      const bankAccountInfo: BankAccountInfo = {
+        accountType: "checking",
+        accountPurpose: "personal",
+        holderType: "individual",
+        holderTaxId: {
+          type: "cpf",
+          value: "12345678901"
+        },
+        country: "BR",
+        ispbCode: "12345678",
+        branchCode: "0001",
+        accountNumber: "987654",
+        accountCheckDigit: "0",
+        pixKeys: [
+          { type: "email", value: "user@example.com" },
+          { type: "phone", value: "+5511999999999" }
+        ]
+      }
+
       const payment = await IncogniaApi.registerPayment({
         requestToken: 'request_token',
         accountId: 'account_id',
@@ -337,24 +356,8 @@ describe('Incognia API', () => {
         externalId: 'external_id',
         policyId: 'policy_id',
         coupon: { type: CouponType.FixedValue, value: 10 },
-        bankAccountInfo: {
-              accountType: "checking",
-              accountPurpose: "personal",
-              holderType: "individual",
-              holderTaxId: {
-                type: "cpf",
-                value: "12345678901"
-              },
-              country: "BR",
-              ispbCode: "12345678",
-              branchCode: "0001",
-              accountNumber: "987654",
-              accountCheckDigit: "0",
-              pixKeys: [
-                { type: "email", value: "user@example.com" },
-                { type: "phone", value: "+5511999999999" }
-              ]
-          }
+        debtorAccount: bankAccountInfo,
+        creditorAccount: bankAccountInfo
       })
       expect(payment).toEqual(expectedResponse)
     })

--- a/test/incogniaApi.test.ts
+++ b/test/incogniaApi.test.ts
@@ -315,6 +315,50 @@ describe('Incognia API', () => {
       expect(payment).toEqual(expectedResponse)
     })
 
+    it('registers payment with bank account info', async () => {
+      const apiResponse = {
+        id: '5e76a7ca-577c-4f47-a752-9e1e0cee9e49',
+        risk_assessment: 'low_risk'
+      }
+
+      const expectedResponse = {
+        id: '5e76a7ca-577c-4f47-a752-9e1e0cee9e49',
+        riskAssessment: 'low_risk'
+      }
+
+      nock(BASE_ENDPOINT)
+        .post(`/v2/authentication/transactions`)
+        .reply(200, apiResponse)
+
+      const payment = await IncogniaApi.registerPayment({
+        requestToken: 'request_token',
+        accountId: 'account_id',
+        appId: 'app_id',
+        externalId: 'external_id',
+        policyId: 'policy_id',
+        coupon: { type: CouponType.FixedValue, value: 10 },
+        bankAccountInfo: {
+              accountType: "checking",
+              accountPurpose: "personal",
+              holderType: "individual",
+              holderTaxId: {
+                type: "cpf",
+                value: "12345678901"
+              },
+              country: "BR",
+              ispbCode: "12345678",
+              branchCode: "0001",
+              accountNumber: "987654",
+              accountCheckDigit: "0",
+              pixKeys: [
+                { type: "email", value: "user@example.com" },
+                { type: "phone", value: "+5511999999999" }
+              ]
+          }
+      })
+      expect(payment).toEqual(expectedResponse)
+    })
+
     describe.each([
       ['without collectedAt', undefined],
       ['with collectedAt', new Date('2024-01-01T12:00:00Z')]


### PR DESCRIPTION
## Proposed changes

Adds `debtorAccount` and `creditorAccount` fields to the `registerPayment` method

## Checklist
- [x] Style check and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested on the live API endpoint